### PR TITLE
controller: make garp_max_timeout configurable

### DIFF
--- a/controller/ovn-controller.8.xml
+++ b/controller/ovn-controller.8.xml
@@ -338,6 +338,17 @@
         heplful to pin source outer IP for the tunnel when multiple interfaces
         are used on the host for overlay traffic.
       </dd>
+      <dt><code>external_ids:garp-max-timeout-sec</code></dt>
+      <dd>
+        When used, this configuration value specifies the maximum timeout
+        (in seconds) between two consecutive GARP packets sent by
+        <code>ovn-controller</code>.
+        <code>ovn-controller</code> by default sends just 4 GARP packets
+        with an exponential backoff timeout.
+        Setting <code>external_ids:garp-max-timeout-sec</code> allows to
+        cap for the exponential backoff used by <code>ovn-controller</code>
+        to send GARPs packets.
+      </dd>
     </dl>
 
     <p>

--- a/controller/ovn-controller.c
+++ b/controller/ovn-controller.c
@@ -2491,7 +2491,9 @@ main(int argc, char *argv[])
                                         ovnsb_idl_loop.idl),
                                     br_int, chassis,
                                     &runtime_data->local_datapaths,
-                                    &runtime_data->active_tunnels);
+                                    &runtime_data->active_tunnels,
+                                    ovsrec_open_vswitch_table_get(
+                                            ovs_idl_loop.idl));
                         if (engine_node_changed(&en_runtime_data)) {
                             update_sb_monitors(ovnsb_idl_loop.idl, chassis,
                                                &runtime_data->local_lports,

--- a/controller/pinctrl.h
+++ b/controller/pinctrl.h
@@ -27,6 +27,7 @@ struct lport_index;
 struct ovsdb_idl_index;
 struct ovsdb_idl_txn;
 struct ovsrec_bridge;
+struct ovsrec_open_vswitch_table;
 struct sbrec_chassis;
 struct sbrec_dns_table;
 struct sbrec_controller_event_table;
@@ -46,7 +47,8 @@ void pinctrl_run(struct ovsdb_idl_txn *ovnsb_idl_txn,
                  const struct sbrec_service_monitor_table *,
                  const struct ovsrec_bridge *, const struct sbrec_chassis *,
                  const struct hmap *local_datapaths,
-                 const struct sset *active_tunnels);
+                 const struct sset *active_tunnels,
+                 const struct ovsrec_open_vswitch_table *ovs_table);
 void pinctrl_wait(struct ovsdb_idl_txn *ovnsb_idl_txn);
 void pinctrl_destroy(void);
 

--- a/tests/ovn.at
+++ b/tests/ovn.at
@@ -7586,7 +7586,7 @@ OVN_CLEANUP([hv1])
 
 AT_CLEANUP
 
-AT_SETUP([ovn -- send gratuitous arp with nat-addresses router in localnet])
+AT_SETUP([send gratuitous arp with nat-addresses router in localnet])
 ovn_start
 # Create logical switch
 ovn-nbctl ls-add ls0


### PR DESCRIPTION
When using VLAN backed networks and OVN routers leveraging the 'ovn-chassis-mac-mappings' option for east-west traffic, the eth.src field is replaced by the chassis mac address in order to not expose the router mac address from different nodes and confuse the TOR switch. However doing so the TOR switch is not able to learn the port/mac bindings for routed E/W traffic and it is force to always flood it. Fix this issue adding the capability to configure a given timeout for garp sent by ovn-controller and not disable it after the exponential backoff in order to keep refreshing the entries in TOR swtich fdb table.
More into about the issue can be found here [0].

[0] https://mail.openvswitch.org/pipermail/ovs-discuss/2020-September/050678.html
Reported-at: https://bugzilla.redhat.com/show_bug.cgi?id=2087779


Acked-by: Ales Musil <amusil@redhat.com>